### PR TITLE
Enable screenshots for non-local providers (S3, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add strapi-plugin-video-thumbnail
 
 # Supported Providers
 - [x] Local
-- [ ] AWS S3
+- [x] AWS S3
 
 # How does this plugin works?
 1. This plugin overrides Upload model's `beforeCreate` database lifecycle hook on [bootstrap.js](https://github.com/darron1217/strapi-plugin-video-thumbnail/blob/main/config/functions/bootstrap.js)

--- a/services/video-thumbnail.js
+++ b/services/video-thumbnail.js
@@ -6,7 +6,8 @@
  * @description: A set of functions similar to controller's actions to avoid code duplication.
  */
 
-const fs = require('fs');
+ const http = require('https');
+ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const os = require('os');
@@ -15,10 +16,6 @@ const ffmpeg = require('fluent-ffmpeg');
 
 module.exports = {
   async generateThumbnail(videoData) {
-    if (videoData.provider !== 'local') {
-      // This plugin currently supports local provider only
-      return;
-    }
 
     const screenshotData = await getScreenshot(videoData);
 
@@ -69,10 +66,7 @@ const getScreenshot = (videoData) =>
       strapi.config.paths.static,
     );
     const publicPath = path.resolve(strapi.dir, configPublicPath);
-    const videoPath = path.join(
-      publicPath,
-      `/uploads/${videoData.hash}${videoData.ext}`,
-    );
+    var videoPath;
 
     // Create temp folder
     const tmpPath = path.join(
@@ -83,6 +77,18 @@ const getScreenshot = (videoData) =>
 
     const screenshotExt = '.png';
     const screenshotFileName = videoData.hash + screenshotExt;
+
+    if(videoData.provider !== 'local') {
+      videoPath = fs.createWriteStream(path.join(tmpPath, videoData.name));
+      const request = http.get(videoData.path, function(response) {
+        response.pipe(file);
+      });
+    } else {
+      videoPath = path.join(
+        publicPath,
+        `/uploads/${videoData.hash}${videoData.ext}`,
+      );
+    }
 
     // Take screenshot
     try {


### PR DESCRIPTION
Where the provider is not local but the videoData includes a url then the video will be downloaded to the tmp directory to enable screenshot generation.

Tested with "strapi-provider-upload-do"