### PR TITLE
Add Support for S3 Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add strapi-plugin-video-thumbnail
 
 # Supported Providers
 - [x] Local
-- [ ] AWS S3
+- [x] AWS S3
 
 # How does this plugin works?
 1. This plugin overrides Upload model's `beforeCreate` database lifecycle hook on [bootstrap.js](https://github.com/darron1217/strapi-plugin-video-thumbnail/blob/main/config/functions/bootstrap.js)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git@github.com:darron1217/strapi-plugin-video-thumbnail.git"
   },
   "dependencies": {
+    "aws-sdk": "^2.1043.0",
     "fluent-ffmpeg": "^2.1.2",
     "strapi-plugin-upload": "^3.4.4"
   },


### PR DESCRIPTION
Add support for S3 Upload.
It use S3 signed url.

p.s. By default, S3 signed url is expired in 7 days

In previous implementation(#2), file is downloaded and saved to local.
But it doesn't need to be downloaded, because ffmpeg supports url as input parameter.